### PR TITLE
ci: add self-hosting configuration using 3.2 for artifacts

### DIFF
--- a/.buildkite/pipeline.node-modules.yml
+++ b/.buildkite/pipeline.node-modules.yml
@@ -1,6 +1,7 @@
 env:
   BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0: "docker-compose.yml"
   BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1: "docker-compose.buildkite.yml"
+  MONOFO_HOOK_DEBUG: "1"
 
 monorepo:
   pure: true
@@ -14,13 +15,13 @@ steps:
     key: node-modules
     depends_on:
       - node-image
-    commands:
-      - yarn install --frozen-lockfile
-      - tar -c --use-compress-program="lz4 -2" -f node-modules.tar.lz4 node_modules
+    command: yarn install --frozen-lockfile
     timeout_in_minutes: 20
     plugins:
       - docker-compose#v3.9.0:
           run: node
-      - artifacts#v1.5.0:
-          upload: node-modules.tar.lz4
+      - vital-software/monofo#v3.2.1:
+          upload:
+            node-modules.tar.lz4:
+              - ./node_modules/
 

--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -21,12 +21,11 @@ steps:
     branches: main next next-major beta alpha
     plugins:
       - improbable-eng/metahook#v0.4.1:
-          pre-command: >
-            buildkite-agent artifact download node-modules.tar.lz4 . && tar -x --use-compress-program=lz4 -f node-modules.tar.lz4 && rm -rf node-modules.tar.lz4 &
-            buildkite-agent artifact download typescript.tar.lz4 . && tar -x --use-compress-program=lz4 -f typescript.tar.lz4 && rm -rf typescript.tar.lz4 &
-            wait
-
-            git fetch --tags -f # Until we stop clobbering tags during artifact rollout
+          pre-command: git fetch --tags -f # To allow mutating build tags for now
+      - vital-software/monofo#v3.2.1:
+          download:
+            - node-modules.tar.lz4
+            - typescript.tar.lz4
       - docker-compose#v3.9.0:
           run: node
       - seek-oss/aws-sm#v2.3.1:

--- a/.buildkite/pipeline.test.yml
+++ b/.buildkite/pipeline.test.yml
@@ -19,11 +19,10 @@ monorepo:
 templates:
   # Plugin templates
   - &pre-command
-    improbable-eng/metahook#v0.4.1:
-      pre-command: >
-        buildkite-agent artifact download node-modules.tar.lz4 . && tar -x --use-compress-program=lz4 -f node-modules.tar.lz4 && rm -rf node-modules.tar.lz4 &
-        buildkite-agent artifact download typescript.tar.lz4 . && tar -x --use-compress-program=lz4 -f typescript.tar.lz4 && rm -rf typescript.tar.lz4 &
-        wait
+    vital-software/monofo#v3.2.1:
+      download:
+        - node-modules.tar.lz4
+        - typescript.tar.lz4
   - &dc
     docker-compose#v3.9.0:
       run: node

--- a/.buildkite/pipeline.typescript.yml
+++ b/.buildkite/pipeline.typescript.yml
@@ -20,13 +20,13 @@ steps:
       - node-modules
     commands:
       - yarn build
-      - tar -c --use-compress-program="lz4 -2" -f typescript.tar.lz4 dist/
     timeout_in_minutes: 20
     plugins:
-      - improbable-eng/metahook#v0.4.1:
-          pre-command: buildkite-agent artifact download node-modules.tar.lz4 . && tar -x --use-compress-program=lz4 -f node-modules.tar.lz4 && rm -rf node-modules.tar.lz4
       - docker-compose#v3.9.0:
           run: node
-      - artifacts#v1.5.0:
+      - vital-software/monofo#v3.2.1:
+          download:
+            - node-modules.tar.lz4
           upload:
-            - typescript.tar.lz4
+            typescript.tar.lz4:
+              - ./dist/

--- a/plugin.yml
+++ b/plugin.yml
@@ -15,7 +15,7 @@ configuration:
     upload:
       type: object
       patternProperties:
-        '^[^/]*\.tar(\.lz4|\.caidx)?$':
+        '^[^/]+$':
           oneOf:
             - type: array
               items:


### PR DESCRIPTION
Uses the artifact support to drive the Monofo build using itself as a plugin (version 3.2.0 is hard-coded and won't be automatically updated, to prevent a bad release from breaking the build)