### PR TITLE
ci: use desync for build artifacts

### DIFF
--- a/.buildkite/pipeline.env.yml
+++ b/.buildkite/pipeline.env.yml
@@ -1,5 +1,5 @@
 env:
-  MONOFO_DESYNC_STORE: "s3+https://s3.amazonaws.com/vital-buildkite-cache-us-west-2/desync/store"
+  MONOFO_DESYNC_STORE: "s3+https://s3-us-west-2.amazonaws.com/vital-buildkite-cache-us-west-2/desync/store"
   MONOFO_DESYNC_CACHE: "/tmp/desync/monofo"
 
 monorepo:

--- a/.buildkite/pipeline.node-modules.yml
+++ b/.buildkite/pipeline.node-modules.yml
@@ -8,7 +8,7 @@ monorepo:
   matches:
     - package.json
     - yarn.lock
-  produces: node-modules.tar.lz4
+  produces: node-modules.caidx
 
 steps:
   - name: ":yarn: Install"
@@ -20,8 +20,8 @@ steps:
     plugins:
       - docker-compose#v3.9.0:
           run: node
-      - vital-software/monofo#v3.4.3:
+      - vital-software/monofo#v3.5.1:
           upload:
-            node-modules.tar.lz4:
+            node-modules.caidx:
               - ./node_modules/
 

--- a/.buildkite/pipeline.node-modules.yml
+++ b/.buildkite/pipeline.node-modules.yml
@@ -1,7 +1,6 @@
 env:
   BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0: "docker-compose.yml"
   BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1: "docker-compose.buildkite.yml"
-  MONOFO_HOOK_DEBUG: "1"
 
 monorepo:
   pure: true

--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -22,9 +22,9 @@ steps:
     plugins:
       - improbable-eng/metahook#v0.4.1:
           pre-command: git fetch --tags -f # To allow mutating build tags for now
-      - vital-software/monofo#v3.4.3:
+      - vital-software/monofo#v3.5.1:
           download:
-            - node-modules.tar.lz4
+            - node-modules.caidx
             - typescript.tar.lz4
       - docker-compose#v3.9.0:
           run: node

--- a/.buildkite/pipeline.test.yml
+++ b/.buildkite/pipeline.test.yml
@@ -6,7 +6,7 @@ env:
 monorepo:
   pure: true
   expects:
-    - node-modules.tar.lz4
+    - node-modules.caidx
     - typescript.tar.lz4
   matches:
     - "**/*.ts"
@@ -39,9 +39,9 @@ steps:
     command: yarn test
     <<: *step
     plugins:
-      - vital-software/monofo#v3.4.3:
+      - vital-software/monofo#v3.5.1:
           download:
-            - node-modules.tar.lz4
+            - node-modules.caidx
             - typescript.tar.lz4
       - *dc
 
@@ -50,8 +50,8 @@ steps:
     command: yarn lint
     <<: *step
     plugins:
-      - vital-software/monofo#v3.4.3:
+      - vital-software/monofo#v3.5.1:
           download:
-            - node-modules.tar.lz4
+            - node-modules.caidx
             - typescript.tar.lz4
       - *dc

--- a/.buildkite/pipeline.typescript.yml
+++ b/.buildkite/pipeline.typescript.yml
@@ -4,7 +4,7 @@ env:
 
 monorepo:
   pure: true
-  expects: node-modules.tar.lz4
+  expects: node-modules.caidx
   matches:
     - "**/*.ts"
     - tsconfig.json
@@ -24,9 +24,9 @@ steps:
     plugins:
       - docker-compose#v3.9.0:
           run: node
-      - vital-software/monofo#v3.4.3:
+      - vital-software/monofo#v3.5.1:
           download:
-            - node-modules.tar.lz4
+            - node-modules.caidx
           upload:
             typescript.tar.lz4:
               - ./dist/


### PR DESCRIPTION
Swaps the file extension of the build artifacts to `.caidx`, telling Monofo to use `desync` to transparently deflate/inflate the archive