### PR TITLE
fix: add support for STS credentials via config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "mkdirp": "1.0.4",
     "rimraf": "3.0.2",
     "split2": "4.1.0",
+    "tempy": "1.0.1",
     "tiny-async-pool": "1.2.0",
     "toposort": "2.0.2"
   },
@@ -114,7 +115,6 @@
     "prettier": "2.5.1",
     "semantic-release": "18.0.1",
     "stdout-stderr": "0.1.13",
-    "tempy": "1.0.1",
     "ts-jest": "27.1.2",
     "typescript": "4.5.4"
   },

--- a/test/commands/upload.test.ts
+++ b/test/commands/upload.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import { promisify } from 'util';
-import { directory } from 'tempy';
+import tempy from 'tempy';
 import { upload } from '../../src/artifacts/api';
 import Upload from '../../src/commands/upload';
 import { fakeProcess, testRun } from '../fixtures';
@@ -26,7 +26,7 @@ describe('cmd upload', () => {
   });
 
   it('can upload a list of files, null separated', async () => {
-    await directory.task(async (dir) => {
+    await tempy.directory.task(async (dir) => {
       process.chdir(dir);
 
       await writeFile(`${dir}/foo.txt`, 'bar');
@@ -45,7 +45,7 @@ describe('cmd upload', () => {
   });
 
   it('can upload a with globs', async () => {
-    await directory.task(async (dir) => {
+    await tempy.directory.task(async (dir: string) => {
       process.chdir(dir);
 
       await writeFile(`${dir}/foo.txt`, 'bar');


### PR DESCRIPTION
Because otherwise time-limited credentials aren't supported

Because https://github.com/folbricht/desync/blob/651a6cea14a080326bb64b28b82c14495c2028ff/cmd/desync/config.go#L67