### PR TITLE
feat: allow `matches: true` to opt out of PIPELINE_RUN_ONLY

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -58,11 +58,13 @@ function updateDecisionsForEnvVars(configs: Config[]): void {
     }
 
     if (process.env?.PIPELINE_RUN_ONLY) {
-      const included = config.monorepo.name === process.env?.PIPELINE_RUN_ONLY;
-      config.decide(
-        included,
-        new Reason(included ? IncludeReasonType.FORCED : ExcludeReasonType.FORCED, ['PIPELINE_RUN_ONLY'])
-      );
+      if (config.monorepo.matches === true) {
+        config.decide(true, new Reason(IncludeReasonType.PIPELINE_ONLY_OPT_OUT));
+      } else if (config.monorepo.name === process.env?.PIPELINE_RUN_ONLY) {
+        config.decide(true, new Reason(IncludeReasonType.FORCED, ['PIPELINE_RUN_ONLY']));
+      } else {
+        config.decide(false, new Reason(ExcludeReasonType.FORCED, ['PIPELINE_RUN_ONLY']));
+      }
     }
 
     const envVarName = config.envVarName();

--- a/src/reason.ts
+++ b/src/reason.ts
@@ -6,6 +6,7 @@ export enum IncludeReasonType {
   FORCED = 'been forced to by',
   NO_FILE_MATCH = 'no files match',
   NO_PREVIOUS_SUCCESSFUL = 'no previous successful build, fallback to being included',
+  PIPELINE_ONLY_OPT_OUT = 'been opted-out of PIPELINE_RUN_ONLY via monorepo.matches === true',
 }
 
 export enum ExcludeReasonType {

--- a/test/commands/pipeline.test.ts
+++ b/test/commands/pipeline.test.ts
@@ -112,10 +112,11 @@ describe('monofo pipeline', () => {
 
     expect(pipeline).toBeDefined();
     expect(commandSummary(pipeline.steps)).toStrictEqual([
-      "echo 'inject for: branch-excluded, changed, dependedon, excluded, foo, match-all, match-all-env, match-all-false, match-all-mixed, match-all-true, qux, baz, unreferenced'",
+      "echo 'inject for: branch-excluded, changed, dependedon, excluded, foo, match-all, match-all-env, match-all-false, match-all-mixed, qux, baz, unreferenced'",
       'echo "bar1" | tee bar1',
       'echo "bar2" | tee bar2',
       'echo "included" > included',
+      'echo "match-all-true" > match-all-true',
       'echo "some-long-name" > some-long-name',
     ]);
 

--- a/test/reason.test.ts
+++ b/test/reason.test.ts
@@ -112,7 +112,11 @@ describe('config.reason', () => {
       { name: 'match-all-env', included: false, reason: 'been forced NOT to by PIPELINE_RUN_ONLY' },
       { name: 'match-all-false', included: false, reason: 'been forced NOT to by PIPELINE_RUN_ONLY' },
       { name: 'match-all-mixed', included: false, reason: 'been forced NOT to by PIPELINE_RUN_ONLY' },
-      { name: 'match-all-true', included: false, reason: 'been forced NOT to by PIPELINE_RUN_ONLY' },
+      {
+        name: 'match-all-true',
+        included: true,
+        reason: 'been opted-out of PIPELINE_RUN_ONLY via monorepo.matches === true',
+      },
       { name: 'qux', included: false, reason: 'been forced NOT to by PIPELINE_RUN_ONLY' },
       { name: 'baz', included: false, reason: 'been forced NOT to by PIPELINE_RUN_ONLY' },
       { name: 'some-long-name', included: false, reason: 'been forced NOT to by PIPELINE_RUN_ONLY' },


### PR DESCRIPTION
This makes `matches: true` useful for cases such as setting environment variables, or steps that must always be included.

Currently, they won't happen on e.g. task builds that use `PIPELINE_RUN_ONLY`; this change makes the exception for `matches: true` symmetrical with the exception for `matches: false` that causes opt-out of `PIPELINE_RUN_ALL`