### PR TITLE
ci: pre-cache node-modules.caidx into place

### DIFF
--- a/.buildkite/pipeline.env.yml
+++ b/.buildkite/pipeline.env.yml
@@ -1,4 +1,8 @@
+---
+
 env:
+  BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0: "docker-compose.yml"
+  BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1: "docker-compose.buildkite.yml"
   MONOFO_DESYNC_STORE: "s3+https://s3-us-west-2.amazonaws.com/vital-buildkite-cache-us-west-2/desync/store"
   MONOFO_DESYNC_CACHE: "/tmp/desync/monofo"
   NODE_ENV: development

--- a/.buildkite/pipeline.node-modules.yml
+++ b/.buildkite/pipeline.node-modules.yml
@@ -1,6 +1,4 @@
-env:
-  BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0: "docker-compose.yml"
-  BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1: "docker-compose.buildkite.yml"
+---
 
 monorepo:
   pure: true
@@ -16,10 +14,14 @@ steps:
       - node-image
     command: yarn install --frozen-lockfile
     timeout_in_minutes: 20
+    env:
+      MONOFO_ARTIFACT_NODE_MODULES_BUILD_ID: $MONOFO_BASE_BUILD_ID
+      MONOFO_ARTIFACT_NODE_MODULES_SOFT_FAIL: 1 # because only used for pre-cache
     plugins:
       - docker-compose#v3.9.0:
           run: node
-      - vital-software/monofo#v3.5.3:
+      - vital-software/monofo#v3.6.1:
+          download: node-modules.caidx # pre-cache the old node_modules into place before yarn install
           upload:
             node-modules.caidx:
               - ./node_modules/

--- a/.buildkite/pipeline.plugin-lint.yml
+++ b/.buildkite/pipeline.plugin-lint.yml
@@ -1,3 +1,5 @@
+---
+
 monorepo:
   pure: true
   matches:

--- a/.buildkite/pipeline.plugin-test.yml
+++ b/.buildkite/pipeline.plugin-test.yml
@@ -1,3 +1,5 @@
+---
+
 monorepo:
   pure: true
   matches:

--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -1,7 +1,4 @@
-env:
-  NODE_ENV: development
-  BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0: "docker-compose.yml"
-  BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1: "docker-compose.buildkite.yml"
+---
 
 monorepo:
   matches: true # because whether we should run determined only by branch
@@ -22,7 +19,7 @@ steps:
     plugins:
       - improbable-eng/metahook#v0.4.1:
           pre-command: git fetch --tags -f # To allow mutating build tags for now
-      - vital-software/monofo#v3.5.3:
+      - vital-software/monofo#v3.6.1:
           download:
             - node-modules.caidx
             - typescript.caidx

--- a/.buildkite/pipeline.test.yml
+++ b/.buildkite/pipeline.test.yml
@@ -1,7 +1,4 @@
-env:
-  NODE_ENV: development
-  BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0: "docker-compose.yml"
-  BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1: "docker-compose.buildkite.yml"
+---
 
 monorepo:
   pure: true
@@ -39,7 +36,7 @@ steps:
     command: yarn test
     <<: *step
     plugins:
-      - vital-software/monofo#v3.5.3:
+      - vital-software/monofo#v3.6.1:
           download:
             - node-modules.caidx
             - typescript.caidx
@@ -50,7 +47,7 @@ steps:
     command: yarn lint
     <<: *step
     plugins:
-      - vital-software/monofo#v3.5.3:
+      - vital-software/monofo#v3.6.1:
           download:
             - node-modules.caidx
             - typescript.caidx

--- a/.buildkite/pipeline.typescript.yml
+++ b/.buildkite/pipeline.typescript.yml
@@ -1,6 +1,4 @@
-env:
-  BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0: "docker-compose.yml"
-  BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1: "docker-compose.buildkite.yml"
+---
 
 monorepo:
   pure: true
@@ -24,7 +22,7 @@ steps:
     plugins:
       - docker-compose#v3.9.0:
           run: node
-      - vital-software/monofo#v3.5.3:
+      - vital-software/monofo#v3.6.1:
           download:
             - node-modules.caidx
           upload:


### PR DESCRIPTION
And consolidate build envs

This is a "pre-cache pattern" that we've already used elsewhere, but we haven't tried it out using the new tooling yet.