### PR TITLE
fix: log the generated monofo command

### DIFF
--- a/hooks/lib/generate.bash
+++ b/hooks/lib/generate.bash
@@ -31,7 +31,7 @@ BUILDKITE_AGENT_ACCESS_TOKEN=${BUILDKITE_AGENT_ACCESS_TOKEN:-}
 echo "--- Fetching other branches" >&2
 git fetch -v origin +refs/heads/*:refs/remotes/origin/*
 
-echo "+++ :pipeline: Generating..." >&2
+echo "+++ :pipeline: Generating... going to run ${MONOFO}" >&2
 $MONOFO > "$PIPELINE_FILE"
 
 echo "--- :pipeline: Result" >&2

--- a/src/artifacts/compression/gzip.ts
+++ b/src/artifacts/compression/gzip.ts
@@ -3,7 +3,6 @@ import debug from 'debug';
 import execa, { ExecaReturnValue } from 'execa';
 import { hasBin } from '../../util/exec';
 import { tar } from '../../util/tar';
-import { Artifact } from '../model';
 import { Compression } from './compression';
 
 const log = debug('monofo:artifact:compression:gzip');

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,6 +74,11 @@ export default class Config {
   public changes: string[] = [];
 
   /**
+   * Total set of all changes, even non-matching ones
+   */
+  public allChanges: string[] = [];
+
+  /**
    * Whether this config is currently considered for inclusion in the final pipeline output
    */
   public included?: boolean = false;
@@ -185,10 +190,12 @@ export default class Config {
     const patterns = this.matchPatterns();
 
     if (!changedFiles || changedFiles.length < 1) {
+      this.allChanges = [];
       this.changes = [];
       return;
     }
 
+    this.allChanges = changedFiles;
     this.changes = [
       ...new Set(
         patterns.flatMap((pattern) =>

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -13,12 +13,23 @@ import Reason, { ExcludeReasonType, IncludeReasonType } from './reason';
  */
 function updateDecisionsForChanges(configs: Config[]): void {
   configs.forEach((config) => {
+    if (typeof config.monorepo.matches === 'boolean') {
+      config.decide(
+        config.monorepo.matches,
+        new Reason(config.monorepo.matches ? IncludeReasonType.ALWAYS_INCLUDED : ExcludeReasonType.NEVER_INCLUDED)
+      );
+
+      return; // read: continue the loop
+    }
+
     if (config.changes.length > 0) {
       let reasonType = IncludeReasonType.FILE_MATCH;
 
-      if (typeof config.monorepo.matches === 'boolean') {
-        reasonType = config.monorepo.matches ? IncludeReasonType.ALL_FILE_MATCH : IncludeReasonType.NO_FILE_MATCH;
-      } else if (config.monorepo.matches.indexOf('**') !== -1 || config.monorepo.matches.indexOf('**/*') !== -1) {
+      if (
+        config.changes.length >= config.allChanges.length ||
+        config.monorepo.matches.indexOf('**') !== -1 ||
+        config.monorepo.matches.indexOf('**/*') !== -1
+      ) {
         reasonType = IncludeReasonType.ALL_FILE_MATCH;
       }
 

--- a/src/reason.ts
+++ b/src/reason.ts
@@ -7,6 +7,7 @@ export enum IncludeReasonType {
   NO_FILE_MATCH = 'no files match',
   NO_PREVIOUS_SUCCESSFUL = 'no previous successful build, fallback to being included',
   PIPELINE_ONLY_OPT_OUT = 'been opted-out of PIPELINE_RUN_ONLY via monorepo.matches === true',
+  ALWAYS_INCLUDED = 'been always included by monorepo.matches === true',
 }
 
 export enum ExcludeReasonType {
@@ -16,6 +17,7 @@ export enum ExcludeReasonType {
   FORCED = 'been forced NOT to by',
   NO_PREVIOUS_SUCCESSFUL = 'no previous successful build, fallback to being excluded',
   PIPELINE_RUN_OPT_OUT = 'been opted-out of PIPELINE_RUN_ALL via monorepo.matches === false',
+  NEVER_INCLUDED = 'been always excluded by monorepo.matches === false',
 }
 
 export default class Reason {

--- a/test/reason.test.ts
+++ b/test/reason.test.ts
@@ -48,13 +48,40 @@ describe('config.reason', () => {
       { name: 'included', included: true, reason: 'been forced to by PIPELINE_RUN_INCLUDED' },
       { name: 'match-all', included: true, reason: '4 matching changes: all files match' },
       { name: 'match-all-env', included: true, reason: '4 matching changes: all files match' },
-      { name: 'match-all-false', included: false, reason: 'no matching changes' },
+      { name: 'match-all-false', included: false, reason: 'been always excluded by monorepo.matches === false' },
       { name: 'match-all-mixed', included: true, reason: '4 matching changes: all files match' },
-      { name: 'match-all-true', included: true, reason: '4 matching changes: all files match' },
+      { name: 'match-all-true', included: true, reason: 'been always included by monorepo.matches === true' },
       { name: 'qux', included: false, reason: 'no matching changes' },
       { name: 'baz', included: true, reason: '1 matching change: baz/abc.ts' },
       { name: 'some-long-name', included: false, reason: 'no matching changes' },
       { name: 'unreferenced', included: true, reason: '4 matching changes: all files match' },
+    ]);
+  });
+
+  it('matches expected reasons when no changes', async () => {
+    const reasons = await getInclusionReasons([]);
+
+    expect(reasons).toStrictEqual([
+      {
+        name: 'branch-excluded',
+        included: false,
+        reason: 'a branches configuration which excludes the current branch',
+      },
+      { name: 'changed', included: false, reason: 'no matching changes' },
+      { name: 'dependedon', included: false, reason: 'no matching changes' },
+      { name: 'excluded', included: false, reason: 'been forced NOT to by PIPELINE_NO_RUN_EXCLUDED' },
+      { name: 'foo', included: false, reason: 'no matching changes' },
+      { name: 'bar', included: false, reason: 'no matching changes' },
+      { name: 'included', included: true, reason: 'been forced to by PIPELINE_RUN_INCLUDED' },
+      { name: 'match-all', included: false, reason: 'no matching changes' },
+      { name: 'match-all-env', included: false, reason: 'no matching changes' },
+      { name: 'match-all-false', included: false, reason: 'been always excluded by monorepo.matches === false' },
+      { name: 'match-all-mixed', included: false, reason: 'no matching changes' },
+      { name: 'match-all-true', included: true, reason: 'been always included by monorepo.matches === true' },
+      { name: 'qux', included: false, reason: 'no matching changes' },
+      { name: 'baz', included: false, reason: 'no matching changes' },
+      { name: 'some-long-name', included: false, reason: 'no matching changes' },
+      { name: 'unreferenced', included: false, reason: 'no matching changes' },
     ]);
   });
 


### PR DESCRIPTION
In this build: https://buildkite.com/vital/monofo/builds/3246#2edc895a-b0dc-4f7f-bda3-a7b56f3e9b19

The `pipeline.env.yml` had `matches: true`, but it wasn't included!