### PR TITLE
feat: use tar-fs to create a tar file

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -20,6 +20,11 @@ This list can be passed using:
  - a list of glob expressions, or
  - a file containing a list of paths to include
 
+The glob expressions and paths must be relative, and point to locations below
+the working directory. Intermediate directories between the working directory
+and the target paths will be included in the archive as (otherwise empty) 
+placeholder structure.
+
 Passing `-` as the file to read from will cause `upload` to read the list of
 files from `stdin` - this allows e.g. using `find -print0` to produce a list
 of matching files to upload.

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "mkdirp": "1.0.4",
     "rimraf": "3.0.2",
     "split2": "4.1.0",
+    "tar-fs": "2.1.1",
     "tempy": "1.0.1",
     "tiny-async-pool": "1.2.0",
     "toposort": "2.0.2"
@@ -99,6 +100,7 @@
     "@types/mkdirp": "1.0.2",
     "@types/rimraf": "3.0.2",
     "@types/split2": "3.2.1",
+    "@types/tar-fs": "2.0.1",
     "@types/tempy": "0.3.0",
     "@types/tiny-async-pool": "1.0.0",
     "@types/toposort": "2.0.3",

--- a/src/artifacts/api.ts
+++ b/src/artifacts/api.ts
@@ -1,7 +1,7 @@
 import stream from 'stream';
 import debug from 'debug';
-import execa from 'execa';
 import got from 'got';
+import { exec } from '../util/exec';
 import { Artifact } from './model';
 
 const log = debug('monofo:artifact:api');
@@ -27,7 +27,7 @@ export async function search(artifact: Artifact): Promise<string> {
 
   log(`Calling buildkite-agent ${args.join(' ')}`);
 
-  return (await execa('buildkite-agent', args, { stderr: 'inherit' })).stdout.split('\n')[0];
+  return (await exec('buildkite-agent', args, { stderr: 'inherit' })).stdout.split('\n')[0];
 }
 
 /**
@@ -39,7 +39,7 @@ export async function search(artifact: Artifact): Promise<string> {
  * @param artifact The artifact to upload
  */
 export async function upload(artifact: Artifact): Promise<void> {
-  await execa('buildkite-agent', ['artifact', 'upload', artifact.filename], {
+  await exec('buildkite-agent', ['artifact', 'upload', artifact.filename], {
     stdio: ['inherit', 'inherit', 'inherit'],
   });
 }

--- a/src/artifacts/compression/compression.ts
+++ b/src/artifacts/compression/compression.ts
@@ -9,11 +9,11 @@ export interface Compression {
    * inflate decompresses an input stream (usually an in-progress artifact download), writing decompressed files to disk
    * at the given outputPath (usually the working dir)
    */
-  inflate(input: stream.Readable, outputPath?: string): Promise<execa.ExecaReturnValue>;
+  inflate(options: { input: stream.Readable; outputPath?: string; verbose?: boolean }): Promise<execa.ExecaReturnValue>;
 
   /**
-   * deflate either takes a tar, or creates on on the fly, and passes this to a compression algorithm, outputting the
+   * deflate either takes a tar, or creates one on the fly, and passes this to a compression algorithm, outputting the
    * desired artifact
    */
-  deflate(output: Artifact, tarInputArgs: TarInputArgs): Promise<execa.ExecaChildProcess>;
+  deflate(options: { output: Artifact; tarInputArgs: TarInputArgs }): Promise<execa.ExecaChildProcess>;
 }

--- a/src/artifacts/compression/compression.ts
+++ b/src/artifacts/compression/compression.ts
@@ -1,8 +1,5 @@
 import stream from 'stream';
-import execa from 'execa';
 import { Artifact } from '../model';
-
-export type TarInputArgs = { argv: string[]; input: string } | { file: string };
 
 export interface Compression {
   /**

--- a/src/artifacts/compression/compression.ts
+++ b/src/artifacts/compression/compression.ts
@@ -9,11 +9,11 @@ export interface Compression {
    * inflate decompresses an input stream (usually an in-progress artifact download), writing decompressed files to disk
    * at the given outputPath (usually the working dir)
    */
-  inflate(options: { input: stream.Readable; outputPath?: string; verbose?: boolean }): Promise<execa.ExecaReturnValue>;
+  inflate(options: { input: stream.Readable; outputPath?: string; verbose?: boolean }): Promise<unknown>;
 
   /**
    * deflate either takes a tar, or creates one on the fly, and passes this to a compression algorithm, outputting the
    * desired artifact
    */
-  deflate(options: { output: Artifact; tarInputArgs: TarInputArgs }): Promise<execa.ExecaChildProcess>;
+  deflate(options: { output: Artifact; tarStream: stream.Readable }): Promise<unknown>;
 }

--- a/src/artifacts/compression/desync.ts
+++ b/src/artifacts/compression/desync.ts
@@ -9,7 +9,6 @@ import rimrafCb from 'rimraf';
 import tempy from 'tempy';
 import { exec, hasBin } from '../../util/exec';
 import { Compression } from './compression';
-import { execFromTar } from './tar';
 
 const log = debug('monofo:artifact:compression:desync');
 
@@ -195,25 +194,29 @@ export const desync: Compression = {
   /**
    * Deflate a tar file, creating a content-addressed index file
    */
-  async deflate({ output, tarInputArgs }): Promise<execa.ExecaChildProcess> {
+  async deflate({ output, tarStream }): Promise<execa.ExecaChildProcess> {
     await checkEnabled();
 
-    return execFromTar(tarInputArgs, [
-      '|',
+    return exec(
       'desync',
-      'tar',
-      '--config',
-      configPath,
-      '--verbose',
-      '--tar-add-root',
-      '--input-format',
-      'tar',
-      '--index',
-      '--store',
-      store(),
-      output.filename,
-      '-',
-    ]);
+      [
+        'tar',
+        '--config',
+        configPath,
+        '--verbose',
+        '--tar-add-root',
+        '--input-format',
+        'tar',
+        '--index',
+        '--store',
+        store(),
+        output.filename,
+        '-',
+      ],
+      {
+        input: tarStream,
+      }
+    );
   },
 
   /**

--- a/src/artifacts/compression/gzip.ts
+++ b/src/artifacts/compression/gzip.ts
@@ -1,9 +1,8 @@
 import debug from 'debug';
 import execa, { ExecaReturnValue } from 'execa';
-import { hasBin } from '../../util/exec';
+import { exec, hasBin } from '../../util/exec';
 import { tar } from '../../util/tar';
 import { Compression } from './compression';
-import { execFromTar } from './tar';
 
 const log = debug('monofo:artifact:compression:gzip');
 
@@ -20,9 +19,12 @@ async function checkEnabled() {
 }
 
 export const gzip: Compression = {
-  async deflate({ output, tarInputArgs }): Promise<execa.ExecaChildProcess> {
+  async deflate({ output, tarStream }): Promise<execa.ExecaChildProcess> {
     await checkEnabled();
-    return execFromTar(tarInputArgs, ['|', 'gzip', '>', output.filename]);
+
+    return exec('gzip', ['>', output.filename], {
+      input: tarStream,
+    });
   },
 
   async inflate({ input, outputPath = '.' }): Promise<ExecaReturnValue> {

--- a/src/artifacts/compression/gzip.ts
+++ b/src/artifacts/compression/gzip.ts
@@ -1,10 +1,8 @@
-import stream from 'stream';
 import debug from 'debug';
 import execa, { ExecaReturnValue } from 'execa';
 import { hasBin } from '../../util/exec';
 import { tar } from '../../util/tar';
-import { Artifact } from '../model';
-import { Compression, TarInputArgs } from './compression';
+import { Compression } from './compression';
 import { execFromTar } from './tar';
 
 const log = debug('monofo:artifact:compression:gzip');
@@ -22,12 +20,12 @@ async function checkEnabled() {
 }
 
 export const gzip: Compression = {
-  async deflate(output: Artifact, tarInputArgs: TarInputArgs): Promise<execa.ExecaChildProcess> {
+  async deflate({ output, tarInputArgs }): Promise<execa.ExecaChildProcess> {
     await checkEnabled();
     return execFromTar(tarInputArgs, ['|', 'gzip', '>', output.filename]);
   },
 
-  async inflate(input: stream.Readable, outputPath = '.'): Promise<ExecaReturnValue> {
+  async inflate({ input, outputPath = '.' }): Promise<ExecaReturnValue> {
     await checkEnabled();
 
     const tarBin = await tar();

--- a/src/artifacts/compression/gzip.ts
+++ b/src/artifacts/compression/gzip.ts
@@ -34,7 +34,7 @@ export const gzip: Compression = {
 
     log(`Inflating .tar.gz archive: ${tarBin.bin} -C ${outputPath} -xzf -`);
 
-    const result = await execa(tarBin.bin, ['-C', outputPath, '-xzf', '-'], {
+    const result = await exec(tarBin.bin, ['-C', outputPath, '-xzf', '-'], {
       input,
     });
 

--- a/src/artifacts/compression/index.ts
+++ b/src/artifacts/compression/index.ts
@@ -27,7 +27,7 @@ export function deflator(output: Artifact, tarInputArgs: TarInputArgs): Promise<
     throw new Error(`Unsupported output artifact format: ${output.ext}`);
   }
 
-  return compressor.deflate(output, tarInputArgs);
+  return compressor.deflate({ output, tarInputArgs });
 }
 
 export async function inflator(
@@ -47,5 +47,5 @@ export async function inflator(
     return exec('cat', ['>', artifact.filename], { input });
   }
 
-  return compressor.inflate(input, outputPath);
+  return compressor.inflate({ input, outputPath });
 }

--- a/src/artifacts/compression/index.ts
+++ b/src/artifacts/compression/index.ts
@@ -3,7 +3,7 @@ import debug from 'debug';
 import execa from 'execa';
 import { exec } from '../../util/exec';
 import { Artifact } from '../model';
-import { Compression, TarInputArgs } from './compression';
+import { Compression } from './compression';
 import { desync } from './desync';
 import { gzip } from './gzip';
 import { lz4 } from './lz4';
@@ -20,21 +20,17 @@ export const compressors: Record<string, Compression> = {
   tar,
 };
 
-export function deflator(output: Artifact, tarInputArgs: TarInputArgs): Promise<execa.ExecaChildProcess> {
+export function deflator(output: Artifact, tarStream: stream.Readable): Promise<unknown> {
   const compressor = compressors?.[output.ext];
 
   if (!compressor) {
     throw new Error(`Unsupported output artifact format: ${output.ext}`);
   }
 
-  return compressor.deflate({ output, tarInputArgs });
+  return compressor.deflate({ output, tarStream });
 }
 
-export async function inflator(
-  input: stream.Readable,
-  artifact: Artifact,
-  outputPath = '.'
-): Promise<execa.ExecaChildProcess> {
+export async function inflator(input: stream.Readable, artifact: Artifact, outputPath = '.'): Promise<unknown> {
   if (artifact.skip) {
     log(`Skipping download and inflate for ${artifact.name} because skip is enabled`);
     return Promise.resolve(execa('true'));

--- a/src/artifacts/compression/lz4.ts
+++ b/src/artifacts/compression/lz4.ts
@@ -31,7 +31,7 @@ export const lz4: Compression = {
     await checkEnabled();
     log(`Inflating .tar.lz4 archive: tar -C ${outputPath} -x --use-compress-program=lz4 -f -`);
 
-    const result = await execa((await tar()).bin, ['-C', outputPath, '-x', '--use-compress-program=lz4', '-f', '-'], {
+    const result = await exec((await tar()).bin, ['-C', outputPath, '-x', '--use-compress-program=lz4', '-f', '-'], {
       input,
     });
 

--- a/src/artifacts/compression/lz4.ts
+++ b/src/artifacts/compression/lz4.ts
@@ -1,10 +1,8 @@
-import stream from 'stream';
 import debug from 'debug';
 import execa, { ExecaReturnValue } from 'execa';
 import { hasBin } from '../../util/exec';
 import { tar } from '../../util/tar';
-import { Artifact } from '../model';
-import { Compression, TarInputArgs } from './compression';
+import { Compression } from './compression';
 import { execFromTar } from './tar';
 
 const log = debug('monofo:artifact:compression:lz4');
@@ -22,12 +20,12 @@ async function checkEnabled() {
 }
 
 export const lz4: Compression = {
-  async deflate(output: Artifact, tarInputArgs: TarInputArgs): Promise<execa.ExecaChildProcess> {
+  async deflate({ output, tarInputArgs }): Promise<execa.ExecaChildProcess> {
     await checkEnabled();
     return execFromTar(tarInputArgs, ['|', 'lz4', '-2', '>', output.filename]);
   },
 
-  async inflate(input: stream.Readable, outputPath = '.'): Promise<ExecaReturnValue> {
+  async inflate({ input, outputPath = '.' }): Promise<ExecaReturnValue> {
     await checkEnabled();
     log(`Inflating .tar.lz4 archive: tar -C ${outputPath} -x --use-compress-program=lz4 -f -`);
 

--- a/src/artifacts/compression/lz4.ts
+++ b/src/artifacts/compression/lz4.ts
@@ -1,9 +1,8 @@
 import debug from 'debug';
 import execa, { ExecaReturnValue } from 'execa';
-import { hasBin } from '../../util/exec';
+import { exec, hasBin } from '../../util/exec';
 import { tar } from '../../util/tar';
 import { Compression } from './compression';
-import { execFromTar } from './tar';
 
 const log = debug('monofo:artifact:compression:lz4');
 
@@ -20,9 +19,12 @@ async function checkEnabled() {
 }
 
 export const lz4: Compression = {
-  async deflate({ output, tarInputArgs }): Promise<execa.ExecaChildProcess> {
+  async deflate({ output, tarStream }): Promise<execa.ExecaChildProcess> {
     await checkEnabled();
-    return execFromTar(tarInputArgs, ['|', 'lz4', '-2', '>', output.filename]);
+
+    return exec('lz4', ['-2', '>', output.filename], {
+      input: tarStream,
+    });
   },
 
   async inflate({ input, outputPath = '.' }): Promise<ExecaReturnValue> {

--- a/src/artifacts/compression/tar.ts
+++ b/src/artifacts/compression/tar.ts
@@ -50,13 +50,13 @@ export function execFromTar(
 }
 
 export const tar: Compression = {
-  async deflate(artifact, tarInputArgs): Promise<execa.ExecaChildProcess> {
+  async deflate({ output, tarInputArgs }): Promise<execa.ExecaChildProcess> {
     await checkEnabled();
 
-    return execFromTar(tarInputArgs, ['>', artifact.filename]);
+    return execFromTar(tarInputArgs, ['>', output.filename]);
   },
 
-  async inflate(input: stream.Readable, outputPath = '.'): Promise<ExecaReturnValue> {
+  async inflate({ input, outputPath = '.' }): Promise<ExecaReturnValue> {
     await checkEnabled();
 
     log(`Inflating .tar archive: tar -C ${outputPath} -x -f -`);

--- a/src/artifacts/compression/tar.ts
+++ b/src/artifacts/compression/tar.ts
@@ -2,10 +2,10 @@ import fs from 'fs';
 import { pipeline as pipelineCb } from 'stream';
 import util from 'util';
 import debug from 'debug';
-import execa, { ExecaReturnValue } from 'execa';
-import { EmptyArgsError, exec, hasBin } from '../../util/exec';
+import { ExecaReturnValue } from 'execa';
+import { exec, hasBin } from '../../util/exec';
 import { tar as tarBin } from '../../util/tar';
-import { Compression, TarInputArgs } from './compression';
+import { Compression } from './compression';
 
 const pipeline = util.promisify(pipelineCb);
 

--- a/src/artifacts/matcher.ts
+++ b/src/artifacts/matcher.ts
@@ -64,6 +64,7 @@ export async function filesToUpload({
       filesFrom === '-' ? process.stdin : fs.createReadStream(filesFrom, { encoding: 'utf8', autoClose: true });
 
     matching.push(pipeline(source, split(useNull ? '\x00' : '\n'), matched));
+    // TODO: pipeline is sync here anyway, so this can be simplified
   }
 
   await Promise.all(matching);

--- a/src/artifacts/matcher.ts
+++ b/src/artifacts/matcher.ts
@@ -1,40 +1,67 @@
-import fs from 'fs';
-import stream, { pipeline as pipelineSync } from 'stream';
-import { promisify } from 'util';
+import { promises as fs, PathLike } from 'fs';
+import path from 'path';
 import debug from 'debug';
 import _ from 'lodash';
-import split from 'split2';
 import { globSet } from '../util/glob';
-import { depthSort } from '../util/tar';
+import { count } from '../util/helper';
 
-const pipeline = promisify(pipelineSync);
+const exists = async (file: string) => {
+  try {
+    await fs.stat(file);
+    return true;
+  } catch (err) {
+    return false;
+  }
+};
 
 const log = debug('monofo:artifact:matcher');
 
-/**
- * Utility class that can act as a writable stream of file name chunks, or receive globs
- */
-class MatchedFiles extends stream.Writable {
-  constructor(private _matched: string[] = []) {
-    super({
-      objectMode: true,
-      write: (chunk: string, _encoding, next) => {
-        this._matched.push(chunk);
-        next();
-      },
-    });
-  }
-
-  async addGlobs(globs: string[]): Promise<void> {
-    this._matched = [...this._matched, ...(await globSet(_.castArray(globs), { matchBase: false }))];
-  }
-
-  get matched() {
-    return this._matched;
-  }
+export interface PathsToPack {
+  [path: string]: { recurse: boolean };
 }
 
-export async function filesToUpload({
+function isRoot(p: string): boolean {
+  return p === '' || p === '/' || p === '.';
+}
+
+export function addIntermediateDirectories(toPack: PathsToPack): PathsToPack {
+  const repacked: PathsToPack = {};
+
+  const addWithParents = (p: string, recurse: boolean): void => {
+    if (isRoot(p)) {
+      return;
+    }
+
+    const parent = path.dirname(p);
+
+    if (!isRoot(parent) && !(parent in repacked)) {
+      log(`Adding intermediate directory to included paths to upload: ${parent}`);
+      addWithParents(parent, false);
+    }
+
+    repacked[p] = { recurse };
+  };
+
+  for (const [p, { recurse }] of Object.entries(toPack)) {
+    addWithParents(p, recurse);
+  }
+
+  return repacked;
+}
+
+/**
+ * The files will be passed to tar in the order shown, and then tar will
+ * recurse into each entry if it's a directory (because --recursive is the
+ * default) - it should use the --sort argument (if your tar is new enough)
+ * to sort the eventual input file list, but they'll still be ordered according
+ * to the order of this files argument
+ *
+ * This is problematic if the paths don't contain every intermediate directory
+ *
+ * To fix this, and make the eventual tar compatible with catar, we do the
+ * recursion into files ourselves.
+ */
+export async function pathsToUpload({
   filesFrom,
   globs,
   useNull = false,
@@ -42,31 +69,40 @@ export async function filesToUpload({
   filesFrom?: string;
   globs?: string[];
   useNull?: boolean;
-}): Promise<string[]> {
+}): Promise<Record<string, { recurse: boolean }>> {
   if (!filesFrom && !globs) {
-    return [];
+    return {};
   }
 
-  const matched = new MatchedFiles();
-  const matching: Promise<void>[] = [];
-
-  if (globs) {
-    matching.push(matched.addGlobs(globs));
-  }
+  const paths: Record<string, { recurse: boolean }> = Object.fromEntries(
+    (
+      await globSet(
+        _.castArray(globs).filter((v) => v),
+        { matchBase: false }
+      )
+    ).map((p) => [`./${p}`, { recurse: false }])
+  );
 
   if (filesFrom) {
-    if (filesFrom !== '-' && !fs.existsSync(filesFrom)) {
+    if (filesFrom !== '-' && !(await exists(filesFrom))) {
       throw new Error(`Could not find file to read file list from: ${filesFrom}`);
     }
 
     log(`Reading from ${filesFrom !== '-' ? filesFrom : 'stdin'}`);
-    const source: stream.Readable =
-      filesFrom === '-' ? process.stdin : fs.createReadStream(filesFrom, { encoding: 'utf8', autoClose: true });
+    const source: string =
+      filesFrom === '-'
+        ? await fs.readFile(0 as unknown as PathLike, 'utf8') // 0 is process.stdin
+        : await fs.readFile(filesFrom, { encoding: 'utf8' });
 
-    matching.push(pipeline(source, split(useNull ? '\x00' : '\n'), matched));
-    // TODO: pipeline is sync here anyway, so this can be simplified
+    for (const p of source.split(useNull ? '\x00' : '\n').filter((v) => v)) {
+      paths[p] = { recurse: true };
+    }
   }
 
-  await Promise.all(matching);
-  return depthSort(matched.matched);
+  if (!Object.keys(paths).every((p) => p.startsWith('./'))) {
+    throw new Error('Expected to be given only relative paths to recurse, relative to CWD');
+  }
+
+  log(`Globs and file input matched ${count(Object.keys(paths), 'path')}`);
+  return addIntermediateDirectories(paths);
 }

--- a/src/commands/deflate.ts
+++ b/src/commands/deflate.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from 'fs';
+import { promises as fs, createReadStream } from 'fs';
 import debug from 'debug';
 import { deflator } from '../artifacts/compression';
 import { Artifact } from '../artifacts/model';
@@ -25,7 +25,7 @@ export default class Deflate extends BaseCommand {
     },
   ];
 
-  async run(): Promise<string> {
+  async run(): Promise<void> {
     const { args } = this.parse<unknown, DeflateArguments>(Deflate);
 
     try {
@@ -39,9 +39,6 @@ export default class Deflate extends BaseCommand {
       throw err;
     }
 
-    const artifact = new Artifact(args.output);
-
-    const result = await deflator(artifact, { file: args.tarFile });
-    return result.stdout;
+    await deflator(new Artifact(args.output), createReadStream(args.tarFile));
   }
 }

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -5,7 +5,7 @@ import { flags as f } from '@oclif/command';
 import debug from 'debug';
 import { upload } from '../artifacts/api';
 import { deflator } from '../artifacts/compression';
-import { PathsToPack, pathsToUpload } from '../artifacts/matcher';
+import { PathsToPack, pathsToPack } from '../artifacts/matcher';
 import { Artifact } from '../artifacts/model';
 import { BaseCommand, BaseFlags } from '../command';
 import { produceTarStream } from '../util/tar';
@@ -103,7 +103,7 @@ locally cached
 
     const artifact = new Artifact(args.output);
 
-    const paths: PathsToPack = await pathsToUpload({
+    const paths: PathsToPack = await pathsToPack({
       globs: args.globs,
       filesFrom: flags['files-from'],
       useNull: flags.null,
@@ -114,7 +114,7 @@ locally cached
       return;
     }
 
-    const tarStream = produceTarStream(paths);
+    const tarStream = await produceTarStream(paths);
 
     if (flags['debug-tar']) {
       log(`Writing debug tar to ${flags['debug-tar']}`);

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -1,17 +1,13 @@
-import stream from 'stream';
-import { promisify } from 'util';
 import { flags as f } from '@oclif/command';
 import debug from 'debug';
-import execa from 'execa';
 import { upload } from '../artifacts/api';
 import { deflator } from '../artifacts/compression';
 import { filesToUpload } from '../artifacts/matcher';
 import { Artifact } from '../artifacts/model';
 import { BaseCommand, BaseFlags } from '../command';
+import { exec } from '../util/exec';
 import { count } from '../util/helper';
 import { tar } from '../util/tar';
-
-const pipeline = promisify(stream.pipeline);
 
 const log = debug('monofo:cmd:upload');
 
@@ -119,7 +115,7 @@ locally cached
 
     log(`About to run: ${tarBin.bin} ${tarArgs.join(' ')} <<< '${files.join(',')}'`);
 
-    const subprocess = execa(tarBin.bin, tarArgs, {
+    const subprocess = exec(tarBin.bin, tarArgs, {
       stdout: 'pipe',
       buffer: false,
       input: `${files.join('\x00')}\x00`,

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -100,6 +100,13 @@ locally cached
       return;
     }
 
+    /*
+     * The files will be passed to tar in the order shown, and then tar will
+     * recurse into each entry if it's a directory (because --recursive is the
+     * default) - it should use the --sort argument (if your tar is new enough)
+     * to sort the eventual input file list, but they'll still be ordered according
+     * to the order of this files argument
+     */
     log(`Uploading ${count(files, 'path')} as ${args.output}`, files);
 
     const tarBin = await tar();

--- a/src/util/exec.ts
+++ b/src/util/exec.ts
@@ -22,12 +22,12 @@ export class EmptyArgsError extends Error {
 /**
  * Announces what it's about to execute, then runs it, returning the output
  */
-export async function exec(
+export function exec(
   command: string,
   args: string[],
   options: execa.Options = {},
   verbose = false
-): Promise<execa.ExecaChildProcess> {
+): execa.ExecaChildProcess {
   const opts: execa.Options = {
     shell: 'bash',
     stderr: verbose ? 'inherit' : undefined,
@@ -37,16 +37,21 @@ export async function exec(
 
   logUpdate(`${chalk.yellow('Running...')} ${command} ${args.join(' ')}...`);
 
-  try {
-    const result = await execa(command, args, opts);
-    logUpdate(`${chalk.green('Done:')}      ${command} ${args.join(' ')}\t✅ `);
-    logUpdate.done();
+  const subprocess: execa.ExecaChildProcess = execa(command, args, opts);
 
-    return result;
-  } catch (err) {
-    logUpdate(`${chalk.red('Error:')}     ${command} ${args.join(' ')}\t❌ `);
-    logUpdate.done();
+  void subprocess
+    .then((v) => {
+      logUpdate(`${chalk.green('Done:')}      ${command} ${args.join(' ')}\t✅ `);
+      logUpdate.done();
 
-    throw err;
-  }
+      return v;
+    })
+    .catch((err) => {
+      logUpdate(`${chalk.red('Error:')}     ${command} ${args.join(' ')}\t❌ `);
+      logUpdate.done();
+
+      throw err;
+    });
+
+  return subprocess;
 }

--- a/src/util/exec.ts
+++ b/src/util/exec.ts
@@ -1,3 +1,4 @@
+import stream from 'stream';
 import chalk from 'chalk';
 import commandExists from 'command-exists';
 import debug from 'debug';
@@ -13,10 +14,12 @@ export function hasBin(bin: string): Promise<boolean> {
     .catch(() => false);
 }
 
-export class EmptyArgsError extends Error {
-  constructor() {
-    super('Expected argv to contain at least one argument');
+export function getReadableFromProcessStdout(process: execa.ExecaChildProcess): stream.Readable {
+  if (!process.stdout) {
+    throw new Error();
   }
+
+  return process.stdout;
 }
 
 /**

--- a/src/util/exec.ts
+++ b/src/util/exec.ts
@@ -25,11 +25,12 @@ export class EmptyArgsError extends Error {
 export async function exec(
   command: string,
   args: string[],
-  options: execa.Options = {}
+  options: execa.Options = {},
+  verbose = false
 ): Promise<execa.ExecaChildProcess> {
   const opts: execa.Options = {
     shell: 'bash',
-    stderr: 'inherit',
+    stderr: verbose ? 'inherit' : undefined,
 
     ...options,
   };

--- a/src/util/exec.ts
+++ b/src/util/exec.ts
@@ -1,3 +1,5 @@
+import { ChildProcess } from 'child_process';
+import { createWriteStream } from 'fs';
 import stream from 'stream';
 import chalk from 'chalk';
 import commandExists from 'command-exists';
@@ -14,9 +16,9 @@ export function hasBin(bin: string): Promise<boolean> {
     .catch(() => false);
 }
 
-export function getReadableFromProcessStdout(process: execa.ExecaChildProcess): stream.Readable {
+export function getReadableFromProcess(process: ChildProcess): stream.Readable {
   if (!process.stdout) {
-    throw new Error();
+    throw new Error('Expected stdout from process');
   }
 
   return process.stdout;
@@ -57,4 +59,10 @@ export function exec(
     });
 
   return subprocess;
+}
+
+export function streamToFile(inputStream: stream.Readable, filePath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    inputStream.pipe(createWriteStream(filePath)).on('finish', resolve).on('error', reject);
+  });
 }

--- a/src/util/helper.ts
+++ b/src/util/helper.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import _ from 'lodash';
 
 export const plurals = (n: number): string => (n === 1 ? '' : 's');
@@ -10,8 +11,23 @@ export function strings(v: undefined | string[] | string): string[] {
   if (!v || v.length <= 0) {
     return [];
   }
+
   if (_.isArray(v)) {
     return v;
   }
+
   return [String(v)];
+}
+
+/**
+ * number of ch occurances in str without .split() (less allocations)
+ */
+export function charCount(haystack: string, needleChar: string): number {
+  return _.sumBy(haystack, (x: string) => (x === needleChar ? 1 : 0));
+}
+
+export function depthSort(paths: string[]): string[] {
+  return _.uniq(paths)
+    .sort()
+    .sort((p1, p2) => p1.split(path.sep).length - p2.split(path.sep).length);
 }

--- a/src/util/helper.ts
+++ b/src/util/helper.ts
@@ -1,3 +1,4 @@
+import { promises as fs } from 'fs';
 import path from 'path';
 import _ from 'lodash';
 
@@ -30,4 +31,13 @@ export function depthSort(paths: string[]): string[] {
   return _.uniq(paths)
     .sort()
     .sort((p1, p2) => p1.split(path.sep).length - p2.split(path.sep).length);
+}
+
+export async function exists(file: string): Promise<boolean> {
+  try {
+    await fs.stat(file);
+    return true;
+  } catch (err) {
+    return false;
+  }
 }

--- a/src/util/tar.ts
+++ b/src/util/tar.ts
@@ -48,6 +48,8 @@ export async function tar(): Promise<{ bin: string; createArgs: string[] }> {
       if (matches && compare(matches[1], '1.28', '>=')) {
         createArgs = [...createArgs, '--sort=name']; // --sort was added in 1.28
       }
+
+      createArgs = ['--verbose', ...createArgs];
     }
 
     cachedTarResult = {

--- a/test/artifacts/compression.test.ts
+++ b/test/artifacts/compression.test.ts
@@ -39,11 +39,14 @@ describe('compression', () => {
       const compression: Compression = compressors[extension];
       const compressed = `${dir}/test.${extension}`;
 
-      await compression.deflate(new Artifact(compressed), { file: getFixturePath('qux.tar') });
+      await compression.deflate({
+        output: new Artifact(compressed),
+        tarInputArgs: { file: getFixturePath('qux.tar') },
+      });
 
       expect(fs.existsSync(compressed)).toBe(true);
 
-      await compression.inflate(fs.createReadStream(compressed), dir);
+      await compression.inflate({ input: fs.createReadStream(compressed), outputPath: dir });
 
       expect(fs.existsSync(`${dir}/qux/quux`)).toBe(true);
     });

--- a/test/artifacts/compression.test.ts
+++ b/test/artifacts/compression.test.ts
@@ -26,8 +26,7 @@ describe('compression', () => {
     it('can download and inflate .tar.lz4 files correctly', async () => {
       const artifact = new Artifact('foo.tar.lz4');
 
-      const res = await inflator(fs.createReadStream(getFixturePath('foo.tar.lz4')), artifact);
-      expect(res.exitCode).toBe(0);
+      await inflator(fs.createReadStream(getFixturePath('foo.tar.lz4')), artifact);
 
       expect(fs.existsSync(`${dir}`)).toBe(true);
       expect(fs.existsSync(`${dir}/foo/bar`)).toBe(true);
@@ -41,7 +40,7 @@ describe('compression', () => {
 
       await compression.deflate({
         output: new Artifact(compressed),
-        tarInputArgs: { file: getFixturePath('qux.tar') },
+        tarStream: fs.createReadStream(getFixturePath('qux.tar')),
       });
 
       expect(fs.existsSync(compressed)).toBe(true);

--- a/test/artifacts/matcher.test.ts
+++ b/test/artifacts/matcher.test.ts
@@ -28,9 +28,9 @@ describe('artifact matcher', () => {
     await directory.task(async (dir) => {
       process.chdir(dir);
 
-      await writeFile(`${dir}/foo.txt`, 'bar');
-      await writeFile(`${dir}/bar.txt`, 'baz');
-      await writeFile(`${dir}/file-list.null.txt`, 'foo.txt\x00bar.txt');
+      await writeFile(`${dir}/foo.txt`, `bar\n`);
+      await writeFile(`${dir}/bar.txt`, `baz\n`);
+      await writeFile(`${dir}/file-list.null.txt`, 'foo.txt\x00bar.txt\x00');
 
       const result = filesToUpload({
         filesFrom: `${dir}/file-list.null.txt`,
@@ -43,12 +43,31 @@ describe('artifact matcher', () => {
     });
   });
 
+  it('can match a list of files, newline separated', async () => {
+    await directory.task(async (dir) => {
+      process.chdir(dir);
+
+      await writeFile(`${dir}/foo.txt`, 'bar\n');
+      await writeFile(`${dir}/bar.txt`, 'baz\n');
+      await writeFile(`${dir}/file-list.newline.txt`, 'foo.txt\nbar.txt\n');
+
+      const result = filesToUpload({
+        filesFrom: `${dir}/file-list.newline.txt`,
+        useNull: false,
+      });
+
+      await expect(result).resolves.toHaveLength(2);
+      expect(await result).toContain('foo.txt');
+      expect(await result).toContain('bar.txt');
+    });
+  });
+
   it('can match a set of globs', async () => {
     await directory.task(async (dir) => {
       process.chdir(dir);
 
-      await writeFile(`${dir}/foo.txt`, 'bar');
-      await writeFile(`${dir}/bar.txt`, 'baz');
+      await writeFile(`${dir}/foo.txt`, 'bar\n');
+      await writeFile(`${dir}/bar.txt`, 'baz\n');
 
       const result = filesToUpload({
         globs: ['*.txt'],

--- a/test/artifacts/matcher.test.ts
+++ b/test/artifacts/matcher.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import { promisify } from 'util';
 import { directory } from 'tempy';
-import { addIntermediateDirectories, PathsToPack, pathsToUpload } from '../../src/artifacts/matcher';
+import { addIntermediateDirectories, PathsToPack, pathsToPack } from '../../src/artifacts/matcher';
 import { mergeBase, diff, revList } from '../../src/git';
 import { fakeProcess, COMMIT } from '../fixtures';
 
@@ -32,7 +32,7 @@ describe('artifact matcher', () => {
       await writeFile(`${dir}/bar.txt`, `baz\n`);
       await writeFile(`${dir}/file-list.null.txt`, './foo.txt\x00./bar.txt\x00');
 
-      const result = await pathsToUpload({
+      const result = await pathsToPack({
         filesFrom: `${dir}/file-list.null.txt`,
         useNull: true,
       });
@@ -51,7 +51,7 @@ describe('artifact matcher', () => {
       await writeFile(`${dir}/bar.txt`, 'baz\n');
       await writeFile(`${dir}/file-list.newline.txt`, './foo.txt\n./bar.txt\n');
 
-      const result = await pathsToUpload({
+      const result = await pathsToPack({
         filesFrom: `${dir}/file-list.newline.txt`,
         useNull: false,
       });
@@ -69,7 +69,7 @@ describe('artifact matcher', () => {
       await writeFile(`${dir}/foo.txt`, 'bar\n');
       await writeFile(`${dir}/bar.txt`, 'baz\n');
 
-      const result = await pathsToUpload({
+      const result = await pathsToPack({
         globs: ['*.txt'],
       });
 

--- a/test/artifacts/matcher.test.ts
+++ b/test/artifacts/matcher.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import { promisify } from 'util';
 import { directory } from 'tempy';
-import { filesToUpload } from '../../src/artifacts/matcher';
+import { addIntermediateDirectories, PathsToPack, pathsToUpload } from '../../src/artifacts/matcher';
 import { mergeBase, diff, revList } from '../../src/git';
 import { fakeProcess, COMMIT } from '../fixtures';
 
@@ -30,16 +30,16 @@ describe('artifact matcher', () => {
 
       await writeFile(`${dir}/foo.txt`, `bar\n`);
       await writeFile(`${dir}/bar.txt`, `baz\n`);
-      await writeFile(`${dir}/file-list.null.txt`, 'foo.txt\x00bar.txt\x00');
+      await writeFile(`${dir}/file-list.null.txt`, './foo.txt\x00./bar.txt\x00');
 
-      const result = filesToUpload({
+      const result = await pathsToUpload({
         filesFrom: `${dir}/file-list.null.txt`,
         useNull: true,
       });
 
-      await expect(result).resolves.toHaveLength(2);
-      expect(await result).toContain('foo.txt');
-      expect(await result).toContain('bar.txt');
+      expect(result['./foo.txt']).toStrictEqual({ recurse: true });
+      expect(result['./bar.txt']).toStrictEqual({ recurse: true });
+      expect(Object.keys(result)).toHaveLength(2);
     });
   });
 
@@ -49,16 +49,16 @@ describe('artifact matcher', () => {
 
       await writeFile(`${dir}/foo.txt`, 'bar\n');
       await writeFile(`${dir}/bar.txt`, 'baz\n');
-      await writeFile(`${dir}/file-list.newline.txt`, 'foo.txt\nbar.txt\n');
+      await writeFile(`${dir}/file-list.newline.txt`, './foo.txt\n./bar.txt\n');
 
-      const result = filesToUpload({
+      const result = await pathsToUpload({
         filesFrom: `${dir}/file-list.newline.txt`,
         useNull: false,
       });
 
-      await expect(result).resolves.toHaveLength(2);
-      expect(await result).toContain('foo.txt');
-      expect(await result).toContain('bar.txt');
+      expect(Object.keys(result)).toHaveLength(2);
+      expect(result['./foo.txt']).toStrictEqual({ recurse: true });
+      expect(result['./bar.txt']).toStrictEqual({ recurse: true });
     });
   });
 
@@ -69,11 +69,39 @@ describe('artifact matcher', () => {
       await writeFile(`${dir}/foo.txt`, 'bar\n');
       await writeFile(`${dir}/bar.txt`, 'baz\n');
 
-      const result = filesToUpload({
+      const result = await pathsToUpload({
         globs: ['*.txt'],
       });
 
-      return expect(result).resolves.toHaveLength(2);
+      expect(Object.keys(result)).toHaveLength(2);
+      expect(result['./foo.txt']).toStrictEqual({ recurse: false });
+      expect(result['./bar.txt']).toStrictEqual({ recurse: false });
     });
+  });
+});
+
+describe('add intermediate directories', () => {
+  it('adds intermediate dirs', () => {
+    const paths: PathsToPack = {
+      'a/b/c/foo.txt': { recurse: false },
+      'd/e/f/blah.txt': { recurse: false },
+      'h/i/j': { recurse: true },
+    };
+
+    const result = addIntermediateDirectories(paths);
+
+    expect(Object.keys(result)).toStrictEqual([
+      'a',
+      'a/b',
+      'a/b/c',
+      'a/b/c/foo.txt',
+      'd',
+      'd/e',
+      'd/e/f',
+      'd/e/f/blah.txt',
+      'h',
+      'h/i',
+      'h/i/j',
+    ]);
   });
 });

--- a/test/commands/upload.test.ts
+++ b/test/commands/upload.test.ts
@@ -1,8 +1,10 @@
 import { promises as fs } from 'fs';
+import execa from 'execa';
 import mkdirp from 'mkdirp';
 import tempy from 'tempy';
 import { upload } from '../../src/artifacts/api';
 import Upload from '../../src/commands/upload';
+import { tar } from '../../src/util/tar';
 import { fakeProcess, testRun } from '../fixtures';
 
 jest.mock('../../src/artifacts/api');
@@ -29,7 +31,7 @@ describe('cmd upload', () => {
 
       await fs.writeFile(`${dir}/foo.txt`, 'bar');
       await fs.writeFile(`${dir}/bar.txt`, 'baz');
-      await fs.writeFile(`${dir}/file-list.null.txt`, 'foo.txt\x00bar.txt\x00');
+      await fs.writeFile(`${dir}/file-list.null.txt`, './foo.txt\x00./bar.txt\x00');
 
       const { stderr } = await testRun(Upload, [
         '--null',
@@ -65,30 +67,42 @@ describe('cmd upload', () => {
   });
 
   it('can upload a list of directories in the right order, null separated', async () => {
+    jest.setTimeout(100000000);
+
     await tempy.directory.task(async (dir) => {
       process.chdir(dir);
 
       await mkdirp(`${dir}/foo/bar`);
       await mkdirp(`${dir}/foo/baz`);
+      await mkdirp(`${dir}/foo/qux/quux`);
+
       await fs.writeFile(`${dir}/foo/bar/a.txt`, 'a');
       await fs.writeFile(`${dir}/foo/bar/b.txt`, 'b');
       await fs.writeFile(`${dir}/foo/baz/a.txt`, 'a');
       await fs.writeFile(`${dir}/foo/baz/b.txt`, 'b');
+      await fs.writeFile(`${dir}/foo/qux/quux/a.txt`, 'a');
+      await fs.writeFile(`${dir}/foo/qux/quux/b.txt`, 'b');
       await fs.writeFile(`${dir}/foo/a.txt`, 'a');
       await fs.writeFile(`${dir}/foo/b.txt`, 'b');
 
-      // This file list is in the wrong order! https://github.com/folbricht/desync/issues/210
-      await fs.writeFile(`${dir}/file-list.null.txt`, './foo/bar\x00./foo/\x00./foo/baz/\x00');
+      // This file list is missing the foo parent! https://github.com/folbricht/desync/issues/210
+      await fs.writeFile(`${dir}/file-list.null.txt`, './foo/bar\x00./foo/baz/\x00');
 
       const { stderr } = await testRun(Upload, [
         '--null',
         '--files-from',
         `${dir}/file-list.null.txt`,
         'some-upload.tar.gz',
+        'foo/qux/**/*.txt',
       ]);
 
-      expect(stderr).toContain("Uploading 3 paths as some-upload.tar.gz [ './foo/', './foo/bar', './foo/baz/' ]");
+      expect(stderr).toContain('Adding intermediate directory to included paths to upload: ./foo');
+      expect(stderr).toContain('Adding intermediate directory to included paths to upload: ./foo/qux/quux');
+      expect(stderr).toContain('Globs and file input matched 4 paths');
       expect(stderr).toContain('Successfully uploaded some-upload');
+
+      const res = await execa((await tar()).bin, ['-tzf', `${dir}/some-upload.tar.gz`]);
+      expect(res.stdout).toContain('foo');
     });
   });
 

--- a/test/commands/upload.test.ts
+++ b/test/commands/upload.test.ts
@@ -1,12 +1,9 @@
-import * as fs from 'fs';
-import { promisify } from 'util';
+import { promises as fs } from 'fs';
 import mkdirp from 'mkdirp';
 import tempy from 'tempy';
 import { upload } from '../../src/artifacts/api';
 import Upload from '../../src/commands/upload';
 import { fakeProcess, testRun } from '../fixtures';
-
-const writeFile = promisify(fs.writeFile);
 
 jest.mock('../../src/artifacts/api');
 
@@ -30,9 +27,31 @@ describe('cmd upload', () => {
     await tempy.directory.task(async (dir) => {
       process.chdir(dir);
 
-      await writeFile(`${dir}/foo.txt`, 'bar');
-      await writeFile(`${dir}/bar.txt`, 'baz');
-      await writeFile(`${dir}/file-list.null.txt`, 'foo.txt\x00bar.txt\x00');
+      await fs.writeFile(`${dir}/foo.txt`, 'bar');
+      await fs.writeFile(`${dir}/bar.txt`, 'baz');
+      await fs.writeFile(`${dir}/file-list.null.txt`, 'foo.txt\x00bar.txt\x00');
+
+      const { stderr } = await testRun(Upload, [
+        '--null',
+        '--files-from',
+        `${dir}/file-list.null.txt`,
+        'some-upload.tar.gz',
+      ]);
+
+      expect(stderr).toContain('Successfully uploaded some-upload');
+    });
+  });
+
+  it('can expect to be given a list of disparate directories, null separated, must produce catar-like tree', async () => {
+    await tempy.directory.task(async (dir) => {
+      process.chdir(dir);
+
+      await mkdirp(`${dir}/a/b/c/d`);
+      await mkdirp(`${dir}/e/f/g/h`);
+
+      await fs.writeFile(`${dir}/a/b/c/d/foo.txt`, 'bar');
+      await fs.writeFile(`${dir}/e/f/g/h/bar.txt`, 'baz');
+      await fs.writeFile(`${dir}/file-list.null.txt`, './a/b/c/d\x00./e/f/g/h\x00');
 
       const { stderr } = await testRun(Upload, [
         '--null',
@@ -51,15 +70,15 @@ describe('cmd upload', () => {
 
       await mkdirp(`${dir}/foo/bar`);
       await mkdirp(`${dir}/foo/baz`);
-      await writeFile(`${dir}/foo/bar/a.txt`, 'a');
-      await writeFile(`${dir}/foo/bar/b.txt`, 'b');
-      await writeFile(`${dir}/foo/baz/a.txt`, 'a');
-      await writeFile(`${dir}/foo/baz/b.txt`, 'b');
-      await writeFile(`${dir}/foo/a.txt`, 'a');
-      await writeFile(`${dir}/foo/b.txt`, 'b');
+      await fs.writeFile(`${dir}/foo/bar/a.txt`, 'a');
+      await fs.writeFile(`${dir}/foo/bar/b.txt`, 'b');
+      await fs.writeFile(`${dir}/foo/baz/a.txt`, 'a');
+      await fs.writeFile(`${dir}/foo/baz/b.txt`, 'b');
+      await fs.writeFile(`${dir}/foo/a.txt`, 'a');
+      await fs.writeFile(`${dir}/foo/b.txt`, 'b');
 
       // This file list is in the wrong order! https://github.com/folbricht/desync/issues/210
-      await writeFile(`${dir}/file-list.null.txt`, './foo/bar\x00./foo/\x00./foo/baz/\x00');
+      await fs.writeFile(`${dir}/file-list.null.txt`, './foo/bar\x00./foo/\x00./foo/baz/\x00');
 
       const { stderr } = await testRun(Upload, [
         '--null',
@@ -77,8 +96,8 @@ describe('cmd upload', () => {
     await tempy.directory.task(async (dir: string) => {
       process.chdir(dir);
 
-      await writeFile(`${dir}/foo.txt`, 'bar');
-      await writeFile(`${dir}/bar.txt`, 'baz');
+      await fs.writeFile(`${dir}/foo.txt`, 'bar');
+      await fs.writeFile(`${dir}/bar.txt`, 'baz');
 
       const { stderr } = await testRun(Upload, ['some-upload.tar.gz', '*.txt']);
 

--- a/test/util/helper.test.ts
+++ b/test/util/helper.test.ts
@@ -1,4 +1,4 @@
-import { depthSort } from '../../src/util/tar';
+import { depthSort } from '../../src/util/helper';
 
 describe('depthSort', () => {
   it('sorts a nice scenario', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,6 +2830,21 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
+"@types/tar-fs@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/tar-fs/-/tar-fs-2.0.1.tgz#6391dcad1b03dea2d79fac07371585ab54472bb1"
+  integrity sha512-qlsQyIY9sN7p221xHuXKNoMfUenOcvEBN4zI8dGsYbYCqHtTarXOEXSIgUnK+GcR0fZDse6pAIc5pIrCh9NefQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/tar-stream" "*"
+
+"@types/tar-stream@*":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@types/tar-stream/-/tar-stream-2.2.2.tgz#be9d0be9404166e4b114151f93e8442e6ab6fb1d"
+  integrity sha512-1AX+Yt3icFuU6kxwmPakaiGrJUwG44MpuiqPg4dSolRFk6jmvs4b3IbUol9wKDLIgU76gevn3EwE8y/DkSJCZQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/tempy@0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@types/tempy/-/tempy-0.3.0.tgz#e6076cfd5f4ad51b716a26b312a8911825668b0a"
@@ -10345,7 +10360,7 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-tar-fs@^2.0.0, tar-fs@^2.1.1:
+tar-fs@2.1.1, tar-fs@^2.0.0, tar-fs@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
   integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==


### PR DESCRIPTION
This gives more control over what entries we build in. We now check for missing intermediate/parent paths, and add them to the file list to pack (we don't recurse into them however)

We are making some new assumptions that require paths to archive to be relatively underneath the current working directory (so, they must begin with `./`). All the intermediate paths (dirs) from the cwd to the paths-to-be-archived will included as empty directories in the archive.

Fixes #341