### PR TITLE
2 critical fixes

### DIFF
--- a/.buildkite/pipeline.env.yml
+++ b/.buildkite/pipeline.env.yml
@@ -6,7 +6,6 @@ env:
   MONOFO_DESYNC_STORE: "s3+https://s3-us-west-2.amazonaws.com/vital-buildkite-cache-us-west-2/desync/store"
   MONOFO_DESYNC_CACHE: "/tmp/desync/monofo"
   NODE_ENV: development
-  MONOFO_HOOK_DEBUG: 1
 
 monorepo:
   matches: true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
     // Soften some errors
     'no-restricted-syntax': ['warn', 'ForInStatement', 'LabeledStatement', 'WithStatement'], // Removes ForOfStatement from extended standards
     'no-return-assign': ['error', 'except-parens'],
+    'no-await-in-loop': ['warn'],
 
     // And turn some completely off
     'class-methods-use-this': 'off',

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ output/
 oclif.manifest.json
 .combined-docs.md
 .eslintcache
+test/fixtures/desync-store/

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "log-update": "4.0.0",
     "minimatch": "3.0.4",
     "mkdirp": "1.0.4",
+    "pretty-bytes": "5.6.0",
     "rimraf": "3.0.2",
     "split2": "4.1.0",
     "tempy": "1.0.1",

--- a/src/artifacts/compression/compression.ts
+++ b/src/artifacts/compression/compression.ts
@@ -1,8 +1,6 @@
 import stream from 'stream';
 import { Artifact } from '../model';
 
-export type TarInputArgs = { argv: string[]; input: string } | { file: string };
-
 export interface Compression {
   /**
    * inflate decompresses an input stream (usually an in-progress artifact download), writing decompressed files to disk

--- a/src/artifacts/compression/compression.ts
+++ b/src/artifacts/compression/compression.ts
@@ -11,8 +11,9 @@ export interface Compression {
   inflate(options: { input: stream.Readable; outputPath?: string; verbose?: boolean }): Promise<unknown>;
 
   /**
-   * deflate either takes a tar, or creates one on the fly, and passes this to a compression algorithm, outputting the
-   * desired artifact
+   * deflate doesn't do anything, but rather returns a shell script, split into arguments
+   *
+   * The script receives a tar on stdin, and deflates it into a compressed artifact
    */
-  deflate(options: { output: Artifact; tarInputArgs: TarInputArgs }): Promise<unknown>;
+  deflate(output: Artifact): Promise<string[]>;
 }

--- a/src/artifacts/compression/desync.ts
+++ b/src/artifacts/compression/desync.ts
@@ -9,7 +9,6 @@ import rimrafCb from 'rimraf';
 import tempy from 'tempy';
 import { exec, hasBin } from '../../util/exec';
 import { Compression } from './compression';
-import { execFromTar } from './tar';
 
 const log = debug('monofo:artifact:compression:desync');
 
@@ -211,18 +210,6 @@ export const desync: Compression = {
 
         output.filename, // caidx file
         '-',             // tar will be received on input
-
-      // Check for crashes
-      // Samples the 200 bytes of the output, requires it to be larger than 141 bytes, which is an empty .caidx (a truncated .catar is slightly smaller)
-      '&&',
-      '(',
-        'test', `"$(head -c 200 ${output.filename} | wc -c | tr -d ' ')"`, '-gt', '141',
-      '||',
-        '(',
-          'echo', '"detected failure"', '>&2', ';',
-          'exit', '2', ';',
-        ')',
-      ')',
     ];
   },
 

--- a/src/artifacts/compression/desync.ts
+++ b/src/artifacts/compression/desync.ts
@@ -195,11 +195,11 @@ export const desync: Compression = {
   /**
    * Deflate a tar file, creating a content-addressed index file
    */
-  async deflate({ output, tarInputArgs }): Promise<execa.ExecaChildProcess> {
+  async deflate(output): Promise<string[]> {
     await checkEnabled();
 
     // prettier-ignore
-    return execFromTar(tarInputArgs, [
+    return [
       '|',
       'desync', 'tar',
         '--config', configPath,
@@ -223,7 +223,7 @@ export const desync: Compression = {
           'exit', '2', ';',
         ')',
       ')',
-    ]);
+    ];
   },
 
   /**

--- a/src/artifacts/compression/gzip.ts
+++ b/src/artifacts/compression/gzip.ts
@@ -20,9 +20,9 @@ async function checkEnabled() {
 }
 
 export const gzip: Compression = {
-  async deflate({ output, tarInputArgs }): Promise<execa.ExecaChildProcess> {
+  async deflate(output): Promise<string[]> {
     await checkEnabled();
-    return execFromTar(tarInputArgs, ['|', 'gzip', '>', output.filename]);
+    return ['|', 'gzip', '>', output.filename];
   },
 
   async inflate({ input, outputPath = '.' }): Promise<ExecaReturnValue> {

--- a/src/artifacts/compression/gzip.ts
+++ b/src/artifacts/compression/gzip.ts
@@ -3,7 +3,6 @@ import execa, { ExecaReturnValue } from 'execa';
 import { hasBin } from '../../util/exec';
 import { tar } from '../../util/tar';
 import { Compression } from './compression';
-import { execFromTar } from './tar';
 
 const log = debug('monofo:artifact:compression:gzip');
 

--- a/src/artifacts/compression/index.ts
+++ b/src/artifacts/compression/index.ts
@@ -3,7 +3,7 @@ import debug from 'debug';
 import execa from 'execa';
 import { exec } from '../../util/exec';
 import { Artifact } from '../model';
-import { Compression, TarInputArgs } from './compression';
+import { Compression } from './compression';
 import { desync } from './desync';
 import { gzip } from './gzip';
 import { lz4 } from './lz4';

--- a/src/artifacts/compression/index.ts
+++ b/src/artifacts/compression/index.ts
@@ -20,14 +20,14 @@ export const compressors: Record<string, Compression> = {
   tar,
 };
 
-export function deflator(output: Artifact, tarInputArgs: TarInputArgs): Promise<unknown> {
+export function deflator(output: Artifact): Promise<string[]> {
   const compressor = compressors?.[output.ext];
 
   if (!compressor) {
     throw new Error(`Unsupported output artifact format: ${output.ext}`);
   }
 
-  return compressor.deflate({ output, tarInputArgs });
+  return compressor.deflate(output);
 }
 
 export async function inflator(input: stream.Readable, artifact: Artifact, outputPath = '.'): Promise<unknown> {

--- a/src/artifacts/compression/lz4.ts
+++ b/src/artifacts/compression/lz4.ts
@@ -20,9 +20,9 @@ async function checkEnabled() {
 }
 
 export const lz4: Compression = {
-  async deflate({ output, tarInputArgs }): Promise<execa.ExecaChildProcess> {
+  async deflate(output): Promise<string[]> {
     await checkEnabled();
-    return execFromTar(tarInputArgs, ['|', 'lz4', '-2', '>', output.filename]);
+    return ['|', 'lz4', '-2', '>', output.filename];
   },
 
   async inflate({ input, outputPath = '.' }): Promise<ExecaReturnValue> {

--- a/src/artifacts/compression/lz4.ts
+++ b/src/artifacts/compression/lz4.ts
@@ -3,7 +3,6 @@ import execa, { ExecaReturnValue } from 'execa';
 import { hasBin } from '../../util/exec';
 import { tar } from '../../util/tar';
 import { Compression } from './compression';
-import { execFromTar } from './tar';
 
 const log = debug('monofo:artifact:compression:lz4');
 

--- a/src/artifacts/compression/tar.ts
+++ b/src/artifacts/compression/tar.ts
@@ -1,8 +1,8 @@
 import debug from 'debug';
-import execa, { ExecaReturnValue } from 'execa';
-import { EmptyArgsError, exec, hasBin } from '../../util/exec';
+import { ExecaReturnValue } from 'execa';
+import { exec, hasBin } from '../../util/exec';
 import { tar as tarBin } from '../../util/tar';
-import { Compression, TarInputArgs } from './compression';
+import { Compression } from './compression';
 
 const log = debug('monofo:artifact:compression:lz4');
 
@@ -16,36 +16,6 @@ async function checkEnabled() {
   if (!enabled) {
     throw new Error('tar is disabled due to no tar binary found on PATH');
   }
-}
-
-export function tarExecArgs(tarInputArgs: TarInputArgs): string[] {
-  if ('file' in tarInputArgs) {
-    return ['cat', tarInputArgs.file]; // https://porkmail.org/era/unix/award.html#cat
-  }
-
-  return tarInputArgs.argv;
-}
-
-export function tarExecOptions(tarInputArgs: TarInputArgs): Partial<execa.Options> {
-  if ('input' in tarInputArgs) {
-    return { input: tarInputArgs.input };
-  }
-
-  return {};
-}
-
-export function execFromTar(
-  tarInputArgs: TarInputArgs,
-  argv: string[],
-  options: execa.Options = {}
-): Promise<execa.ExecaChildProcess> {
-  const [first, ...rest] = [...tarExecArgs(tarInputArgs), ...argv];
-
-  if (!first) {
-    throw new EmptyArgsError();
-  }
-
-  return exec(first, rest, { ...tarExecOptions(tarInputArgs), ...options });
 }
 
 export const tar: Compression = {

--- a/src/artifacts/compression/tar.ts
+++ b/src/artifacts/compression/tar.ts
@@ -49,10 +49,9 @@ export function execFromTar(
 }
 
 export const tar: Compression = {
-  async deflate({ output, tarInputArgs }): Promise<execa.ExecaChildProcess> {
+  async deflate(output): Promise<string[]> {
     await checkEnabled();
-
-    return execFromTar(tarInputArgs, ['>', output.filename]);
+    return ['>', output.filename];
   },
 
   async inflate({ input, outputPath = '.' }): Promise<ExecaReturnValue> {

--- a/src/commands/deflate.ts
+++ b/src/commands/deflate.ts
@@ -40,6 +40,6 @@ export default class Deflate extends BaseCommand {
     }
 
     const artifact = new Artifact(args.output);
-    await deflator(artifact, { file: args.tarFile });
+    await deflator(artifact);
   }
 }

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -2,9 +2,9 @@ import { flags as f } from '@oclif/command';
 import debug from 'debug';
 import { upload } from '../artifacts/api';
 import { deflator } from '../artifacts/compression';
-import { flattenPathsToFileList, getManifest } from '../artifacts/matcher';
 import { Artifact } from '../artifacts/model';
 import { BaseCommand, BaseFlags } from '../command';
+import { tarArgListForManifest, getManifest } from '../manifest';
 import { count } from '../util/helper';
 import { tar } from '../util/tar';
 
@@ -100,14 +100,14 @@ locally cached
       return;
     }
 
-    const fileList = await flattenPathsToFileList(manifest);
-    log(`Giving ${count(fileList, 'arguments')} to tar as input filelist`);
+    const fileList = await tarArgListForManifest(manifest);
+    log(`Giving ${count(fileList, 'argument')} to tar as input filelist`);
     const input = `${fileList.join('\n')}\n`;
 
     const tarBin = await tar();
     const tarArgs = [
       'set',
-      '-o',
+      '-euo',
       'pipefail',
       ';',
       tarBin.bin,
@@ -118,8 +118,8 @@ locally cached
       '-',
     ];
 
+    log(`Deflating to ${args.output}`);
     await deflator(artifact, { argv: tarArgs, input });
-
     log(`Archive deflated at ${args.output}`);
 
     log('Uploading to Buildkite');

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -1,5 +1,7 @@
+import { promises as fs } from 'fs';
 import { flags as f } from '@oclif/command';
 import debug from 'debug';
+import prettyBytes from 'pretty-bytes';
 import { upload } from '../artifacts/api';
 import { deflator } from '../artifacts/compression';
 import { Artifact } from '../artifacts/model';
@@ -129,7 +131,8 @@ locally cached
     await exec(allArgs[0], allArgs.slice(1), {
       input,
     });
-    log(`Archive deflated at ${args.output}`);
+    const stats = await fs.stat(args.output);
+    log(`Archive deflated at ${args.output} as ${prettyBytes(stats.size)}`);
 
     log('Uploading to Buildkite');
     await upload(artifact);

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -101,6 +101,11 @@ locally cached
     }
 
     const fileList = await tarArgListForManifest(manifest);
+
+    if (!fileList) {
+      throw new Error('Expected file to package');
+    }
+
     log(`Giving ${count(fileList, 'argument')} to tar as input filelist`);
     const input = `${fileList.join('\n')}\n`;
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -3,11 +3,14 @@ import path from 'path';
 import debug from 'debug';
 import _ from 'lodash';
 import tempy from 'tempy';
-import { globSet } from '../util/glob';
-import { count, exists } from '../util/helper';
+import { globSet } from './util/glob';
+import { count, exists } from './util/helper';
 
-const log = debug('monofo:artifact:matcher');
+const log = debug('monofo:manifest');
 
+/**
+ * A manifest is a simple struct for holding tar input items by path
+ */
 export interface Manifest {
   [pathToPack: string]: { recurse: boolean };
 }
@@ -47,7 +50,7 @@ function sequentialGroupsByRecursion(manifest: Manifest): { recurse: boolean; pa
  *
  * @return string A set of tar options, that can be put into a file list or passed as an argv for further processing
  */
-export async function flattenPathsToFileList(manifest: Manifest): Promise<string[]> {
+export async function tarArgListForManifest(manifest: Manifest): Promise<string[]> {
   const groups: { recurse: boolean; paths: string[] }[] = sequentialGroupsByRecursion(manifest).filter(
     ({ paths }) => paths.length > 0
   );

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -38,6 +38,8 @@ function sequentialGroupsByRecursion(manifest: Manifest): { recurse: boolean; pa
     group.paths.push(pathToPack);
   }
 
+  groups.push({ ...group });
+
   return groups;
 }
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -77,6 +77,7 @@ export async function tarArgListForManifest(manifest: Manifest): Promise<string[
 
 export function addIntermediateDirectories(manifest: Manifest): Manifest {
   const repacked: Manifest = {};
+  const added: string[] = [];
 
   const addWithParents = (p: string, recurse: boolean): void => {
     if (isRoot(p)) {
@@ -86,7 +87,7 @@ export function addIntermediateDirectories(manifest: Manifest): Manifest {
     const parent = path.dirname(p);
 
     if (!isRoot(parent) && !(parent in repacked)) {
-      log(`Adding intermediate directory to included paths to upload: ${parent}`);
+      added.push(parent);
       addWithParents(parent, false);
     }
 
@@ -95,6 +96,10 @@ export function addIntermediateDirectories(manifest: Manifest): Manifest {
 
   for (const [p, { recurse }] of Object.entries(manifest)) {
     addWithParents(p, recurse);
+  }
+
+  if (added) {
+    log(`Adding intermediate directories to upload`, added);
   }
 
   return repacked;

--- a/test/artifacts/compression.test.ts
+++ b/test/artifacts/compression.test.ts
@@ -4,6 +4,7 @@ import rimrafCb from 'rimraf';
 import tempy from 'tempy';
 import { Compression, compressors, inflator } from '../../src/artifacts/compression';
 import { Artifact } from '../../src/artifacts/model';
+import { exec } from '../../src/util/exec';
 import { fakeProcess, getFixturePath } from '../fixtures';
 
 const rimraf = promisify(rimrafCb);
@@ -38,10 +39,9 @@ describe('compression', () => {
       const compression: Compression = compressors[extension];
       const compressed = `${dir}/test.${extension}`;
 
-      await compression.deflate({
-        output: new Artifact(compressed),
-        tarInputArgs: { file: getFixturePath('qux.tar') },
-      });
+      const args = await compression.deflate(new Artifact(compressed));
+
+      await exec('cat', [getFixturePath('qux.tar'), ...args]);
 
       expect(fs.existsSync(compressed)).toBe(true);
 

--- a/test/commands/upload.test.ts
+++ b/test/commands/upload.test.ts
@@ -119,9 +119,8 @@ describe('cmd upload', () => {
   });
 
   it('works functionally on ./node_modules/ here', async () => {
-    jest.setTimeout(50000);
     process.chdir(`${__dirname}/../../`);
     const { stderr } = await testRun(Upload, ['node-modules.caidx', './node_modules/']);
     expect(stderr).toContain('Successfully uploaded node-modules');
-  });
+  }, 30000);
 });

--- a/test/commands/upload.test.ts
+++ b/test/commands/upload.test.ts
@@ -96,8 +96,7 @@ describe('cmd upload', () => {
         'foo/qux/**/*.txt',
       ]);
 
-      expect(stderr).toContain('Adding intermediate directory to included paths to upload: ./foo');
-      expect(stderr).toContain('Adding intermediate directory to included paths to upload: ./foo/qux/quux');
+      expect(stderr).toContain("Adding intermediate directories to upload [ './foo/qux/quux', './foo/qux', './foo' ]");
       expect(stderr).toContain('Globs and file input matched 4 paths');
       expect(stderr).toContain('Successfully uploaded some-upload');
 
@@ -117,5 +116,12 @@ describe('cmd upload', () => {
 
       expect(stderr).toContain('Successfully uploaded some-upload');
     });
+  });
+
+  it('works functionally on ./node_modules/ here', async () => {
+    jest.setTimeout(50000);
+    process.chdir(`${__dirname}/../../`);
+    const { stderr } = await testRun(Upload, ['node-modules.caidx', './node_modules/']);
+    expect(stderr).toContain('Successfully uploaded node-modules');
   });
 });

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs';
 import { promisify } from 'util';
 import { directory } from 'tempy';
-import { addIntermediateDirectories, Manifest, getManifest } from '../../src/artifacts/matcher';
-import { mergeBase, diff, revList } from '../../src/git';
-import { fakeProcess, COMMIT } from '../fixtures';
+import { mergeBase, diff, revList } from '../src/git';
+import { addIntermediateDirectories, Manifest, getManifest } from '../src/manifest';
+import { fakeProcess, COMMIT } from './fixtures';
 
 const writeFile = promisify(fs.writeFile);
 

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -7,8 +7,8 @@ import { fakeProcess, COMMIT } from './fixtures';
 
 const writeFile = promisify(fs.writeFile);
 
-jest.mock('../../src/git');
-jest.mock('../../src/buildkite/client');
+jest.mock('../src/git');
+jest.mock('../src/buildkite/client');
 
 const mockMergeBase = mergeBase as jest.Mock<Promise<string>>;
 mockMergeBase.mockImplementation(() => Promise.resolve(COMMIT));

--- a/yarn.lock
+++ b/yarn.lock
@@ -9202,6 +9202,11 @@ prettier@2.5.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
   integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
+pretty-bytes@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
+  integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
+
 pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"


### PR DESCRIPTION
- We were dropping the last block from the file list (tar argv input) - so a bunch of files were being skipped
- Globs were sent to tar as non-recursive, which is correct for some sorts of glob (ones that might match directories _and_ files), but incorrect for others (like a glob such as `./node_modules/` which should be passed on to tar as-is, in recursive-mode)