### PR TITLE
fix(hooks): make plugin conf checks safe for nounset

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -13,7 +13,7 @@ if [[ "${MONOFO_HOOK_DEBUG:-0}" -eq 1 ]]; then
   export DEBUG="*"
 fi
 
-if [[ -z "$BUILDKITE_PLUGIN_CONFIGURATION" ]]; then
+if [[ -z "${BUILDKITE_PLUGIN_CONFIGURATION:-}" ]]; then
   echo "Expected BUILDKITE_PLUGIN_CONFIGURATION to be set" >&2
   exit 1
 fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -13,7 +13,7 @@ if [[ "${MONOFO_HOOK_DEBUG:-0}" -eq 1 ]]; then
   export DEBUG="*"
 fi
 
-if [[ -z "$BUILDKITE_PLUGIN_CONFIGURATION" ]]; then
+if [[ -z "${BUILDKITE_PLUGIN_CONFIGURATION:-}" ]]; then
   echo "Expected BUILDKITE_PLUGIN_CONFIGURATION to be set" >&2
   exit 1
 fi


### PR DESCRIPTION
We use the bash option `set -u` (or "nounset"), which errors if an unset bash variable is accessed, which we did in these `if` checks (so they'd never end up handling the error they intended to; they'd fail before running the `then`)

Now we will print a nice error message and exit politely