### PR TITLE
fix(artifact): error early on non-uuid build ID

### DIFF
--- a/src/artifacts/model.ts
+++ b/src/artifacts/model.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import _ from 'lodash';
 import mkdirp from 'mkdirp';
+import { isUuid } from '../util/helper';
 
 export class Artifact {
   readonly name: string;
@@ -33,7 +34,11 @@ export class Artifact {
     this.buildId = process.env?.[`MONOFO_ARTIFACT_${envName}_BUILD_ID`] || process.env?.BUILDKITE_BUILD_ID;
 
     if (!this.buildId) {
-      throw new Error(`Expected BUILDKITE_BUILD_ID or MONOFO_ARTIFACT_${envName}_BUILD_ID to be set`);
+      throw new Error(`Expected BUILDKITE_BUILD_ID or MONOFO_ARTIFACT_${envName}_BUILD_ID to be set to a UUID`);
+    }
+
+    if (!isUuid(this.buildId)) {
+      throw new Error(`Expected build ID ${this.buildId} to be a UUID`);
     }
 
     // This is a valid fallback, because if we don't pass --build <build-id> this env var would be used anyway

--- a/src/util/helper.ts
+++ b/src/util/helper.ts
@@ -41,3 +41,10 @@ export async function exists(file: string): Promise<boolean> {
     return false;
   }
 }
+
+const UUID_REGEX =
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+
+export function isUuid(input: string): boolean {
+  return input.match(UUID_REGEX) !== null;
+}

--- a/test/artifacts/model.test.ts
+++ b/test/artifacts/model.test.ts
@@ -13,6 +13,12 @@ describe('model Artifact', () => {
     expect(noExtraEnvVar.buildId).toBe(BUILD_ID);
   });
 
+  it('errors early if given an invalid build ID', () => {
+    process.env.BUILDKITE_BUILD_ID = BUILD_ID;
+    process.env.MONOFO_ARTIFACT_NODE_MODULES_BUILD_ID = 'skip';
+    expect(() => new Artifact('node-modules.tar.gz')).toThrowError();
+  });
+
   it.each([
     ['node-modules.tar.gz', 'node-modules', 'tar.gz'],
     ['/some/path/node-modules.tar.gz', 'node-modules', 'tar.gz'],

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -10,8 +10,8 @@ export const PIPELINE = 'monofo';
 export const BRANCH = 'main';
 export const COMMIT = 'f993bd4d8d59b9c70c8092d327c6ac1c6a263b1f';
 export const BUILD_ID = 'f62a1b4d-10f9-4790-bc1c-e2c3a0c80983';
-export const BUILD_ID_2 = 'beefbeef-beef-beef-beef-beefbeefbeef';
-export const BUILD_ID_3 = 'cafecafe-cafe-cafe-cafe-cafecafecafe';
+export const BUILD_ID_2 = 'beefbeef-beef-4eef-aeef-beefbeefbeef';
+export const BUILD_ID_3 = 'cafecafe-cafe-4afe-aafe-cafecafecafe';
 
 export const BASE_BUILD: BuildkiteBuild = {
   blocked: false,

--- a/test/reason.test.ts
+++ b/test/reason.test.ts
@@ -238,7 +238,7 @@ describe('config.reason', () => {
       {
         name: 'foo',
         included: false,
-        reason: 'been built previously in beefbeef-beef-beef-beef-beefbeefbeef (Pure cache hit)',
+        reason: 'been built previously in beefbeef-beef-4eef-aeef-beefbeefbeef (Pure cache hit)',
       },
       { name: 'baz', included: true, reason: '1 matching change: baz/abc.ts (Pure cache missed)' },
     ]);


### PR DESCRIPTION
Relates to #358

Specifically, makes the workaround mentioned in that comment (setting an invalid build ID) cause an early exit, rather than erroring when the Buildkite API gives a 404 response

Has a matching test