### PR TITLE
feat(pipeline): removed the default command alias for pipeline

### DIFF
--- a/src/commands/pipeline.ts
+++ b/src/commands/pipeline.ts
@@ -14,11 +14,6 @@ export default class Pipeline extends BaseCommand {
 
   static override flags = { ...BaseCommand.flags };
 
-  /**
-   * This command is the default one to run if no subcommand is given
-   */
-  static override aliases = [''];
-
   run() {
     return Config.getAll(process.cwd())
       .then((c) =>


### PR DESCRIPTION
Previously, `pipeline` was the default command, and would be called if you passed no sub-command. It's now just a normal command called 'pipeline'

BREAKING CHANGE: If you called `npx monofo` before, you'll now need to call `npx monofo pipeline` explicitly