### PR TITLE
Allow for uuids up to version 7

### DIFF
--- a/.buildkite/pipeline.node-modules.yml
+++ b/.buildkite/pipeline.node-modules.yml
@@ -20,7 +20,7 @@ steps:
     plugins:
       - docker-compose#v3.9.0:
           run: node
-      - vital-software/monofo#v5.0.9:
+      - vital-software/monofo#8ad5f9f76028a51d9ee587e75755a8e85d256977:
           download: node-modules.catar.caibx # pre-cache the old node_modules into place before yarn install
           upload:
             node-modules.catar.caibx:

--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -19,7 +19,7 @@ steps:
     plugins:
       - improbable-eng/metahook#v0.4.1:
           pre-command: git fetch --tags -f # To allow mutating build tags for now
-      - vital-software/monofo#v5.0.9:
+      - vital-software/monofo#8ad5f9f76028a51d9ee587e75755a8e85d256977:
           download:
             - node-modules.catar.caibx
             - typescript.catar.caibx

--- a/.buildkite/pipeline.test.yml
+++ b/.buildkite/pipeline.test.yml
@@ -36,7 +36,7 @@ steps:
     command: yarn test
     <<: *step
     plugins:
-      - vital-software/monofo#v5.0.9:
+      - vital-software/monofo#8ad5f9f76028a51d9ee587e75755a8e85d256977:
           download:
             - node-modules.catar.caibx
             - typescript.catar.caibx
@@ -47,7 +47,7 @@ steps:
     command: yarn lint
     <<: *step
     plugins:
-      - vital-software/monofo#v5.0.9:
+      - vital-software/monofo#8ad5f9f76028a51d9ee587e75755a8e85d256977:
           download:
             - node-modules.catar.caibx
             - typescript.catar.caibx

--- a/.buildkite/pipeline.typescript.yml
+++ b/.buildkite/pipeline.typescript.yml
@@ -22,7 +22,7 @@ steps:
     plugins:
       - docker-compose#v3.9.0:
           run: node
-      - vital-software/monofo#v5.0.9:
+      - vital-software/monofo#8ad5f9f76028a51d9ee587e75755a8e85d256977:
           download:
             - node-modules.catar.caibx
           upload:

--- a/src/util/helper.ts
+++ b/src/util/helper.ts
@@ -43,7 +43,7 @@ export async function exists(file: string): Promise<boolean> {
 }
 
 const UUID_REGEX =
-  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-7][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
 
 export function isUuid(input: string): boolean {
   return input.match(UUID_REGEX) !== null;


### PR DESCRIPTION
## Purpose

`main` is currently blocked due to buildkite suddenly generating uuids that are version _seven_. This is breaking our `isUuid` regex, and breaking all builds.

## Further information
Wikipedia article on uuid format: https://en.wikipedia.org/wiki/Universally_unique_identifier#Format

```
123e4567-e89b-12d3-a456-426614174000
 xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx

The four-bit M and the 1 to 3 bit N fields code the format of the UUID itself.

The four bits of digit M are the UUID version, and the 1 to 3 most significant bits of digit N code the UUID variant. (See [below.](https://en.wikipedia.org/wiki/Universally_unique_identifier#Variants)) In the example, M is 1
```
Sample Id generated by a broken build: 
```
0180bb9f-c455-7877-b8b5-5a660404d36a
              ^ version character
```