### PR TITLE
Relax Buildkite UUID version check

### DIFF
--- a/src/util/helper.ts
+++ b/src/util/helper.ts
@@ -43,7 +43,7 @@ export async function exists(file: string): Promise<boolean> {
 }
 
 const UUID_REGEX =
-  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-7][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
 
 export function isUuid(input: string): boolean {
   return input.match(UUID_REGEX) !== null;


### PR DESCRIPTION
Loosen the Buildkite UUID check following recent UUID change tests from Buildkite that broke deployment of Monofo