### PR TITLE
Fix fallback early exit

### DIFF
--- a/src/commands/pipeline.ts
+++ b/src/commands/pipeline.ts
@@ -29,7 +29,6 @@ export default class Pipeline extends BaseCommand {
     } catch (err: unknown) {
       log('Failed to find base commit or diff changes, falling back to do a full build', err);
       Config.configureFallback(configs);
-      return Promise.resolve();
     }
 
     const yaml = dumpYaml(await mergePipelines(configs));


### PR DESCRIPTION
Refactoring in c1b2cec62c7ea46a9525d0fd53a78822f72be575 meant fallback builds never actually output a pipeline